### PR TITLE
Update pxt.json

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -3,9 +3,7 @@
     "version": "0.1.13",
     "description": "",
     "dependencies": {
-        "core": "*",
-        "radio": "*",
-        "microphone": "*"
+        "core": "*"
     },
     "files": [
         "main.blocks",

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "warte bis...",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "description": "",
     "dependencies": {
         "core": "*"


### PR DESCRIPTION
This removes radio and microphone dependencies, so it will keep Bluetooth enabled and does not load additional v3 only microphone blocks.